### PR TITLE
Fix solver crash when no words found

### DIFF
--- a/Boggle.py
+++ b/Boggle.py
@@ -163,7 +163,17 @@ def in_list(word):
 
 
 def find_longest_word(letterList):
-    return max(all_valid_words(letterList), key=len)
+    """Return the longest valid word for the given board.
+
+    If no valid words exist an empty string is returned instead of raising a
+    ``ValueError``.
+    """
+
+    valid_words = all_valid_words(letterList)
+    if not valid_words:
+        return ""
+
+    return max(valid_words, key=len)
 
 
 def all_valid_words(letterList):


### PR DESCRIPTION
## Summary
- prevent `find_longest_word` from raising `ValueError`

## Testing
- `python -m py_compile Boggle.py`
- `python - <<'PY'
from Boggle import find_longest_word
board=['Q']*16
print(find_longest_word(board))
board=['C','A','T','S','F','O','O','D','B','R','E','A','K','X','Y','Z']
print(find_longest_word(board))
PY`
